### PR TITLE
Fix alphanum to sort string in natural order and loosen validation

### DIFF
--- a/src/alphanum/alphanum.spec.ts
+++ b/src/alphanum/alphanum.spec.ts
@@ -91,7 +91,7 @@ describe('alphanum', (): void => {
       '15.0',
     ];
     list.sort(sut.compare);
-    expect(list).toBe([
+    expect(list).toEqual([
       '1.0',
       '1.2',
       '1.2-SNAPSHOT',

--- a/src/alphanum/alphanum.spec.ts
+++ b/src/alphanum/alphanum.spec.ts
@@ -34,7 +34,7 @@ describe('alphanum', (): void => {
     expect(result).not.toBe(true);
   });
 
-  it('does not allow whitespaces', () => {
+  it('does not allow whitespaces', (): void => {
     const result = sut.valid('1 2 3 4');
     expect(result).not.toBe(true);
   });
@@ -75,7 +75,7 @@ describe('alphanum', (): void => {
     expect(list[5]).toBe('d4');
   });
 
-  it('sorts randomized version array in natural order', () => {
+  it('sorts randomized version array in natural order', (): void => {
     const list = [
       '1.0',
       '2.0',

--- a/src/alphanum/alphanum.spec.ts
+++ b/src/alphanum/alphanum.spec.ts
@@ -19,18 +19,23 @@ describe('alphanum', (): void => {
     expect(result).toBeLessThan(0);
   });
 
-  it('does not validate semver', (): void => {
+  it('does validate dot notation format', (): void => {
     const result = sut.valid('1.1.1');
-    expect(result).not.toBe(true);
+    expect(result).toBe(true);
   });
 
-  it('does not validate float', (): void => {
+  it('does validate float style notation', (): void => {
     const result = sut.valid('1.1');
-    expect(result).not.toBe(true);
+    expect(result).toBe(true);
   });
 
   it('does not validate undefined', (): void => {
     const result = sut.valid(undefined);
+    expect(result).not.toBe(true);
+  });
+
+  it('does not allow whitespaces', () => {
+    const result = sut.valid('1 2 3 4');
     expect(result).not.toBe(true);
   });
 
@@ -54,9 +59,9 @@ describe('alphanum', (): void => {
     expect(result).toBe(true);
   });
 
-  it('validates invalid chars', (): void => {
-    const result = sut.valid('1abc.');
-    expect(result).not.toBe(true);
+  it('validates just about anything', (): void => {
+    const result = sut.valid('1abc.#¤%&%¤&/%/(#¤##¤%&ÖÄÅ_');
+    expect(result).toBe(true);
   });
 
   it('can use sortFn function to sort list', (): void => {
@@ -68,5 +73,37 @@ describe('alphanum', (): void => {
     expect(list[3]).toBe('b5');
     expect(list[4]).toBe('c1');
     expect(list[5]).toBe('d4');
+  });
+
+  it('sorts randomized version array in natural order', () => {
+    const list = [
+      '1.0',
+      '2.0',
+      '1001.0',
+      '3.0',
+      '10.0',
+      '4.0',
+      '1.2',
+      '1.3',
+      '1.2-SNAPSHOT',
+      '100.0',
+      '1000.0',
+      '15.0',
+    ];
+    list.sort(sut.compare);
+    expect(list).toBe([
+      '1.0',
+      '1.2',
+      '1.2-SNAPSHOT',
+      '1.3',
+      '2.0',
+      '3.0',
+      '4.0',
+      '10.0',
+      '15.0',
+      '100.0',
+      '1000.0',
+      '1001.0',
+    ]);
   });
 });

--- a/src/alphanum/alphanum.ts
+++ b/src/alphanum/alphanum.ts
@@ -14,10 +14,10 @@ import { UpdateTypeInterface } from '../updateType';
 
 export class TypeAlphanum extends TypeBase implements UpdateTypeInterface {
   valid(test: string): boolean {
-    const regexp = new RegExp('^[a-zA-Z0-9]*$');
-    return !!test && !!regexp.test(test);
+    const regexp = new RegExp('\\s');
+    return !!test && !regexp.test(test);
   }
   compare(a: string, b: string): number {
-    return a.localeCompare(b);
+    return a.localeCompare(b, 'en', { sensitivity: 'base', numeric: true, ignorePunctuation: true });
   }
 }


### PR DESCRIPTION
Loosen validation to allow any non-whitespace character and implement
natural sort order comparison.
